### PR TITLE
Feat: 회원가입 및 로그인 기능

### DIFF
--- a/src/main/java/com/cooklog/config/SecurityConfig.java
+++ b/src/main/java/com/cooklog/config/SecurityConfig.java
@@ -1,44 +1,61 @@
 
-// package com.cooklog.config;
-//
-// import org.springframework.context.annotation.Bean;
-// import org.springframework.context.annotation.Configuration;
-// import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-// import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-// import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-// import org.springframework.security.web.SecurityFilterChain;
-//
-// @Configuration
-// @EnableWebSecurity
-// public class SecurityConfig{
-// 	@Bean
-// 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception{
-//
-// 		http
-// 			.authorizeHttpRequests((auth) -> auth
-// 				.requestMatchers("/", "/login", "/loginProc","/join","/joinProc").permitAll()
-// 				.requestMatchers("/admin").hasAuthority("ADMIN")
-// 				//                        .requestMatchers("/my/**").hasAnyRole("ADMIN", "USER")
-// 				.anyRequest().authenticated()
-// 			);
-//
-// 		http
-// 			.formLogin((auth) -> auth.loginPage("/login")
-// 				.loginProcessingUrl("/loginProc")
-// 				.usernameParameter("email")
-// 				.permitAll()
-// 			);
-//
-// 		http
-// 			.csrf((auth) -> auth.disable());
-//
-// 		return http.build();
-// 	}
-//
-// 	@Bean
-// 	public BCryptPasswordEncoder bCryptPasswordEncoder() {
-// 		return new BCryptPasswordEncoder();
-// 	}
-//
-// }
+ package com.cooklog.config;
+
+ import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
+ import org.springframework.context.annotation.Bean;
+ import org.springframework.context.annotation.Configuration;
+ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+ import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+ import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+ import org.springframework.security.web.SecurityFilterChain;
+
+
+ @Configuration
+ @EnableWebSecurity
+ public class SecurityConfig{
+
+	 // 특정 HTTP 요청에 대한 웹 기반 보안 구성
+ 	@Bean
+ 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception{
+
+		 // "/", "/login", "/join", "/joinProc 에는 인증 없이 접근 가능하도록 - permitAll()
+ 		http
+ 			.authorizeHttpRequests((auth) -> auth
+ 				.requestMatchers("/", "/login","/join", "/joinProc").permitAll()
+ 				.requestMatchers("/admin").hasAuthority("ADMIN")
+ 				//                        .requestMatchers("/my/**").hasAnyRole("ADMIN", "USER")
+
+ 				.anyRequest().authenticated()
+ 			);
+
+		 // 접근 불가능한 페이지 들어가면 "/login" 으로 이동
+ 		http
+ 			.formLogin((auth) -> auth.loginPage("/login")
+					// 로그인 form action 기본 설정
+ 				.loginProcessingUrl("/loginProc")
+					.defaultSuccessUrl("/")
+ 				.usernameParameter("email")
+ 				.permitAll()
+ 			);
+
+ 		http
+ 			.csrf((auth) -> auth.disable());
+
+ 		return http.build();
+ 	}
+
+	 @Bean
+	 public WebSecurityCustomizer webSecurityCustomizer() {
+		 // 스프링 시큐리티 비활성화 (모든 정적 파일에 ignoring 적용)
+		 return (web) -> web.ignoring().requestMatchers(PathRequest.toStaticResources().atCommonLocations());
+	 }
+
+	 // 패스워드 인코더로 사용할 빈 등록
+ 	@Bean
+ 	public BCryptPasswordEncoder bCryptPasswordEncoder() {
+ 		return new BCryptPasswordEncoder();
+ 	}
+
+ }
 

--- a/src/main/java/com/cooklog/controller/BoardController.java
+++ b/src/main/java/com/cooklog/controller/BoardController.java
@@ -3,13 +3,17 @@ package com.cooklog.controller;
 import com.cooklog.dto.BoardCreateRequestDTO;
 import com.cooklog.dto.BoardDTO;
 import com.cooklog.dto.BoardUpdateRequestDTO;
+import com.cooklog.dto.CustomUserDetails;
 import com.cooklog.model.Board;
 import com.cooklog.model.Tag;
 import com.cooklog.service.BoardService;
 import com.cooklog.service.ImageService;
 import com.cooklog.service.TagService;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -60,7 +64,12 @@ public class BoardController {
 
 	@PostMapping("/write")
 	public ResponseEntity<?> save(BoardCreateRequestDTO boardCreateRequestDTO, @RequestPart("images")List<MultipartFile> images) throws IOException {
-		long userId=1;
+//		long userId=1;
+
+		// 현재 인증된(로그인한) 사용자의 idx 가져옴
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+		long userId = userDetails.getIdx();
 
 		Board board = boardService.save(userId, boardCreateRequestDTO.getContent());
 		List<Tag> tags = tagService.save(boardCreateRequestDTO.getTags(), board);

--- a/src/main/java/com/cooklog/controller/MainController.java
+++ b/src/main/java/com/cooklog/controller/MainController.java
@@ -28,7 +28,7 @@ public class MainController {
     private final ImageService imageService;
     private final CommentService commentService;
 
-    @GetMapping("")
+    @GetMapping("/")
     public String index(@PageableDefault(page = 0, size = 3, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
                         @RequestParam(value = "id", defaultValue = "0") Long lastBoardId, Model model) throws FileNotFoundException {
         long userId = 1;

--- a/src/main/java/com/cooklog/controller/UserController.java
+++ b/src/main/java/com/cooklog/controller/UserController.java
@@ -14,9 +14,7 @@ import com.cooklog.service.UserService;
 @RequiredArgsConstructor
 public class UserController {
 
-
     private final UserService userService;
-
 
     @GetMapping("/user/profile")
     public String userProfile(Model model) {
@@ -29,27 +27,23 @@ public class UserController {
         return "main/index";
     }
 
-    //로그인
+    //로그인 뷰
     @GetMapping("/login")
-    public String loginP() {
+    public String login() {
         return "user/login";
     }
 
-    //회원가입
+    //회원가입 뷰
     @GetMapping("/join")
-    public String joinP() {
+    public String join() {
         return "user/join";
     }
+
+    //회원가입 폼 처리 시 호출됨
     @PostMapping("/joinProc")
-    public String joinProcess(JoinDTO joinDTO) {
-        userService.join(joinDTO);
+    public String joinProc(@ModelAttribute JoinDTO joinDTO) {
+        userService.joinSave(joinDTO);
         return "redirect:/login";
     }
-
-    // @GetMapping("/")
-    // public String mainP() {
-    //     return "user/main";
-    // }
-
 
 }

--- a/src/main/java/com/cooklog/dto/CustomUserDetails.java
+++ b/src/main/java/com/cooklog/dto/CustomUserDetails.java
@@ -12,6 +12,7 @@ public class CustomUserDetails implements UserDetails {
     public CustomUserDetails(User user){
         this.user = user;
     }
+
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
 
@@ -23,19 +24,26 @@ public class CustomUserDetails implements UserDetails {
                 return user.getRole().name();
             }
         });
-
+        // 사용자 권한 정보 반환
         return collection;
     }
 
 
     @Override
     public String getPassword() {
+        // 사용자 비밀번호 반환
         return user.getPassword();
     }
 
     @Override
     public String getUsername() {
+        // 사용자 아이디 반환
         return user.getEmail();
+    }
+
+    public Long getIdx() {
+        // 사용자 아이디(pk) 반환
+        return user.getIdx();
     }
 
     @Override

--- a/src/main/java/com/cooklog/dto/UserDTO.java
+++ b/src/main/java/com/cooklog/dto/UserDTO.java
@@ -36,10 +36,4 @@ public class UserDTO {
 	public UserDTO() {
 
 	}
-
-	//	private String introduction; //마이페이지
-//	private String role; //마이페이지
-//	private String profileImage; //마이페이지
-//	private Boolean isDeleted; //마이페이지
-
 }

--- a/src/main/java/com/cooklog/model/User.java
+++ b/src/main/java/com/cooklog/model/User.java
@@ -1,7 +1,7 @@
 package com.cooklog.model;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -48,12 +48,13 @@ public class User {
 	private boolean isDeleted;
 
 	@OneToMany(mappedBy = "user")
-	private Set<Board> boards = new HashSet<>();
+	private List<Board> boards = new ArrayList<>();
 
 	@Builder
-	public User (String nickname, String email, String password){
+	public User (String nickname, String email, String password, Role role){
 		this.nickname = nickname;
 		this.email = email;
 		this.password = password;
+		this.role = role;
 	}
 }

--- a/src/main/java/com/cooklog/repository/UserRepository.java
+++ b/src/main/java/com/cooklog/repository/UserRepository.java
@@ -8,9 +8,10 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 import java.util.Optional;
 
+// 이메일로 사용자 정보를 가져오기 위해 DB에 요청함
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
-    // Optional<User> findByEmail(String email); //이메일로 사용자 정보 가져오기
+//    Optional<User> findByEmail(String email);
 
     @Override
     List<User> findAll();

--- a/src/main/java/com/cooklog/service/CustomIUserDetailsService.java
+++ b/src/main/java/com/cooklog/service/CustomIUserDetailsService.java
@@ -9,14 +9,16 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
-
+// 시큐리티에서 사용자 정보를 가져오는 서비스 로직
 @Service
 @RequiredArgsConstructor
 public class CustomIUserDetailsService implements UserDetailsService {
     private final UserRepository userRepository;
+
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-
+//        return userRepository.findByEmail(email)
+//                .orElseThrow(() -> new IllegalArgumentException(email));
 
         User userData = userRepository.findByEmail(email);
 

--- a/src/main/java/com/cooklog/service/UserService.java
+++ b/src/main/java/com/cooklog/service/UserService.java
@@ -6,25 +6,25 @@ import com.cooklog.dto.JoinDTO;
 import com.cooklog.dto.UserDTO;
 import com.cooklog.model.Role;
 
-import org.springframework.stereotype.Service;
 import org.springframework.validation.annotation.Validated;
 
-@Service
+import javax.validation.Valid;
+
 @Validated
 public interface UserService {
 
-	//회원 가입
+	//회원 가입 정보 저장
+	void joinSave(JoinDTO joinDTO);
 
-	public void join(JoinDTO joinDTO);
-	
-	//
-	// //이메일 중복 검색
-	// boolean emailExists(String email);
+//	void join(@Valid UserDTO userDTO);
+
+//	//이메일 중복 검색
+//	boolean emailExists(String email);
 
 	UserDTO findUserById(Long id);
 
-	// //비밀번호 유효성 검사
-	// boolean isValidPassword(String password);
+//	//비밀번호 유효성 검사
+//	boolean isValidPassword(String password);
 
 	// 모든 유저의 정보를 가져오는 메소드
 	List<UserDTO> findAllUsers();

--- a/src/main/java/com/cooklog/service/UserServiceImpl.java
+++ b/src/main/java/com/cooklog/service/UserServiceImpl.java
@@ -27,93 +27,76 @@ import javax.validation.Valid;
 @RequiredArgsConstructor
 public class UserServiceImpl implements UserService {
 
-
     private final UserRepository userRepository;
+    private final BCryptPasswordEncoder encoder;
 
-    // private final BCryptPasswordEncoder bCryptPasswordEncoder;
-
+    // JoinDTO 객체를 받아 사용자 정보를 추가(저장)하는 메서드
     @Override
-    public void join(JoinDTO joinDTO){
-        User user = new User();
-
-        boolean isUser = userRepository.existsByEmail(joinDTO.getEmail());
-        if (isUser) {
-            return;
+    public void joinSave(JoinDTO joinDTO) {
+        if (userRepository.existsByEmail(joinDTO.getEmail())) {
+            return; // 이미 가입된 이메일인 경우 메서드 종료
         }
 
-        user.setNickname(joinDTO.getNickname());
-        user.setEmail(joinDTO.getEmail());
-
-//        user.setPassword(bCryptPasswordEncoder.encode(joinDTO.getPassword()));
-
-        user.setRole(Role.USER);
+        User user = User.builder()
+                .nickname(joinDTO.getNickname())
+                .email(joinDTO.getEmail())
+                .password(encoder.encode(joinDTO.getPassword()))
+                .role(Role.USER)
+                .build();
 
         userRepository.save(user);
     }
 
-    // 회원가입
-    //    @Override
-    //    public void join(@Valid UserDTO userDTO) {
-    //        if (emailExists(userDTO.getEmail())) {
-    //            throw new IllegalArgumentException("이미 존재하는 회원입니다: " + userDTO.getEmail());
-    //        }
-    //        //비밀번호 유효성 검사
-    //        isValidPassword(userDTO.getPassword());
-    //
-    //        //이메일 유효성 검사
-    //        if (!isValidEmail(userDTO.getEmail())) {
-    //            throw new IllegalArgumentException("유효하지 않은 이메일 주소입니다: " + userDTO.getEmail());
-    //        }
-    //
-    //        User user = new User(userDTO.getNickname(), userDTO.getEmail(), userDTO.getPassword());
-    //        userRepository.save(user);
-    //    }
-    //
-    //    // 이메일 중복 검사
-    //    public boolean emailExists(String email) {
-    //        return userRepository.findByEmail(email).isPresent();
-    //    }
-    //
-    //    // id로 회원 찾기
-    //    @Override
-    //    public UserDTO findUserById(Long id) {
-    //        User user = userRepository.findById(id).orElse(null);
-    //        if (user != null) {
-    //            UserDTO dto = new UserDTO();
-    //            dto.setNickname(user.getNickname());
-    //            dto.setEmail(user.getEmail());
-    //            return dto;
-    //        }
-    //        return null;
-    //    }
-    //
-    //    // 비밀번호 유효성 검사
-    //    @Override
-    //    public boolean isValidPassword(String password) {
-    //        if (password.length() < 8) {
-    //            throw new IllegalArgumentException("비밀번호는 최소 8자 이상이어야 합니다.");
-    //        }
-    //        if (!password.matches(".*[a-zA-Z].*")) {
-    //            throw new IllegalArgumentException("비밀번호는 영문자를 포함해야 합니다.");
-    //        }
-    //        if (!password.matches(".*\\d.*")) {
-    //            throw new IllegalArgumentException("비밀번호는 숫자를 포함해야 합니다.");
-    //        }
-    //        if (!password.matches(".*[!@#$%^&*()].*")) {
-    //            throw new IllegalArgumentException("비밀번호는 특수문자를 포함해야 합니다.");
-    //        }
-    //        return true;
-    //    }
-    //
-    //    // 이메일 유효성 검사
-    //    public boolean isValidEmail(String email) {
-    //        // 이메일 정규 표현식
-    //        String emailRegex = "^[a-zA-Z0-9_+&*-]+(?:\\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,7}$";
-    //        // 패턴을 컴파일한 Pattern 객체 생성
-    //        Pattern pattern = Pattern.compile(emailRegex);
-    //        // 주어진 이메일이 패턴과 일치하는지 검사하여 반환
-    //        return pattern.matcher(email).matches();
-    //    }
+////     회원가입
+//        @Override
+//        public void join(@Valid UserDTO userDTO) {
+//            if (userRepository.existsByEmail(userDTO.getEmail())) {
+//                throw new IllegalArgumentException("이미 존재하는 회원입니다: " + userDTO.getEmail());
+//            }
+//            //비밀번호 유효성 검사
+//            isValidPassword(userDTO.getPassword());
+//
+//            //이메일 유효성 검사
+//            if (!isValidEmail(userDTO.getEmail())) {
+//                throw new IllegalArgumentException("유효하지 않은 이메일 주소입니다: " + userDTO.getEmail());
+//            }
+//
+//            User user = new User(userDTO.getNickname(), userDTO.getEmail(), userDTO.getPassword(), userDTO.getRole());
+//            userRepository.save(user);
+//        }
+//
+//       // 이메일 중복 검사
+//        public boolean emailExists(String email) {
+//            return userRepository.findByEmail(email).isPresent();
+//        }
+//
+//        // 비밀번호 유효성 검사
+//        @Override
+//        public boolean isValidPassword(String password) {
+//            if (password.length() < 8) {
+//                throw new IllegalArgumentException("비밀번호는 최소 8자 이상이어야 합니다.");
+//            }
+//            if (!password.matches(".*[a-zA-Z].*")) {
+//                throw new IllegalArgumentException("비밀번호는 영문자를 포함해야 합니다.");
+//            }
+//            if (!password.matches(".*\\d.*")) {
+//                throw new IllegalArgumentException("비밀번호는 숫자를 포함해야 합니다.");
+//            }
+//            if (!password.matches(".*[!@#$%^&*()].*")) {
+//                throw new IllegalArgumentException("비밀번호는 특수문자를 포함해야 합니다.");
+//            }
+//            return true;
+//        }
+//
+//        // 이메일 유효성 검사
+//        public boolean isValidEmail(String email) {
+//            // 이메일 정규 표현식
+//            String emailRegex = "^[a-zA-Z0-9_+&*-]+(?:\\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,7}$";
+//            // 패턴을 컴파일한 Pattern 객체 생성
+//            Pattern pattern = Pattern.compile(emailRegex);
+//            // 주어진 이메일이 패턴과 일치하는지 검사하여 반환
+//            return pattern.matcher(email).matches();
+//        }
 
     @Override
     public UserDTO findUserById(Long id) {

--- a/src/main/resources/templates/user/join.html
+++ b/src/main/resources/templates/user/join.html
@@ -53,38 +53,37 @@
     </style>
 </head>
 <body>
+<div class="form-container">
+    <h1 class="center-layout">Cook Log</h1>
+    <form action="/joinProc" method="post">
 
-<h1 class="center-layout">Cook Log</h1>
-
-<form action="/joinProc" method="post" name="joinForm">
-
-    <div class="center-layout">
-        <input type="text" name="nickname" placeholder="id" class="input-container"/>
-    </div>
-
-    <div class="center-layout">
-        <input type="email" name="email" placeholder="Email" class="input-container" />
-    </div>
-
-    <div class="center-layout">
-        <input type="password" name="password" placeholder="Password" class="input-container"/>
-    </div>
-
-
-    <div class="height-size-box"></div>
-    <hr class="line-layout">
-    <div class="height-size-box"></div>
-
-    <div class="center-layout">
-        <div class="block-layout">
-            <button type="submit" value="Join" id="signup-button-container" >
-                <p id="signup-button-text">
-                    회원가입
-                </p>
-            </button>
+        <div class="center-layout">
+            <input type="text" name="nickname" placeholder="id" class="input-container"/>
         </div>
-    </div>
-</form>
 
+        <div class="center-layout">
+            <input type="email" name="email" placeholder="Email" class="input-container" />
+        </div>
+
+        <div class="center-layout">
+            <input type="password" name="password" placeholder="Password" class="input-container"/>
+        </div>
+
+
+        <div class="height-size-box"></div>
+        <hr class="line-layout">
+        <div class="height-size-box"></div>
+
+        <div class="center-layout">
+            <div class="block-layout">
+                <button type="submit" id="signup-button-container" >
+                    <p id="signup-button-text">
+                        회원가입
+                    </p>
+                </button>
+            </div>
+        </div>
+    </form>
+</div>
 </body>
 </html>

--- a/src/main/resources/templates/user/login.html
+++ b/src/main/resources/templates/user/login.html
@@ -99,7 +99,9 @@
                 </button>
                 <p class="center-layout">or 계정이 없으신가요?</p>
 
-                <button id="signup-button-container">
+                <button type="button"
+                        id="signup-button-container"
+                        onclick="location.href='/join'">
                     <h3 id="signup-button-text">가입하기</h3>
                 </button>
             </div>


### PR DESCRIPTION
### 🎈요약
회원가입 및 로그인 기능 구현


### 🗨️작업 내용
1. 회원가입 폼 제출 시 db에 사용자 정보 저장됨 (비밀번호 암호화) / 이미 가입 된 이메일 제출 시 중복 저장 x
![image](https://github.com/HuiGyun-kim/homechef-community/assets/86588506/73e995e8-9915-4064-9812-0276a022bfbd)


2. 로그인 후 글 업로드 시 로그인 한 유저의 nickname이 뜨게 함 (앞단에 뿌리지 않고 뒷단에서 설정)
![image](https://github.com/HuiGyun-kim/homechef-community/assets/86588506/34945708-9987-47a6-8702-b21fac84e4cc)

로그인 한 채로 글 쓰면 board 테이블에 현재 사용자 idx로 잘 가져와짐
![image](https://github.com/HuiGyun-kim/homechef-community/assets/86588506/fa7638ae-7d72-4bf4-835c-a9bbca2bcc94)




### ❗참고 사항
- 유효성, 중복 검사 아직 안됨. 마이페이지 구현 이후에 수정 하겠습니다!
- 기존에 userId 지정해 놓은 부분 주석 처리 해 놨습니다.
- 시큐리티 적용 후 main URL 매핑에 공백을 사용하는 것이 권장되지 않는 것 같아 "/" 로 변경 


### 🔔관련 이슈 
close #42 